### PR TITLE
remove renovate from project

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Fixes #18

**Description**
In Project only have renovate.json file which is I have removed so now no one PR's rise by renovatebot automatically.

I followed this document https://guidebook.devops.uis.cam.ac.uk/howtos/renovatebot/disable-renovatebot/

**This app make changes to below module/s**
- [ ] app
- [ ] core
- [ ] other/documentation

**Please make sure these boxes are checked before submitting your pull request - thanks!**
- [ ] Build the project with `./gradlew build` to make sure you didn't break anything
- [ ] Added the comments particularly in hard-to-understand areas
- [ ] In case of multiple commits please squash them